### PR TITLE
[feature/posts] 게시글(Post)에 대한 CRUD 기능 구현

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class PostController extends Controller
+{
+    /**
+     * 목록 조회 (페이지네이션)
+     * - GET /api/posts?per_page=10&page=1
+     */
+    public function index(Request $request)
+    {
+        $perPage = $request->input('per_page', 10);
+
+        $posts = Post::query()
+            ->latest('created_at')
+            ->paginate($perPage);
+
+        return response()->json($posts);
+    }
+
+    /**
+     * 생성
+     *
+     * - POST /api/posts
+     * body: {"title": "...", "content": "...", "author": "..."}
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'content' => 'required|string',
+            'author' => 'required|string|max:100',
+        ]);
+
+        $post = Post::create($validated);
+
+        return response()->json($post, Response::HTTP_CREATED);
+    }
+
+    /**
+     * 상세 조회
+     * - GET /api/posts/{id}
+     */
+    public function show(Post $post)
+    {
+        return response()->json($post);
+    }
+
+    /**
+     * 수정
+     * - PUT /api/posts/{id} (전체 수정)
+     * - POST /api/posts/{id} (부분 수정)
+     */
+    public function update(Request $request, Post $post)
+    {
+        // 메소드 구분
+        $isPut = strtoupper($request->method()) === 'PUT';
+
+        $rules = [
+            'title' => [$isPut ? 'required' : 'sometimes', 'string', 'max:255'],
+            'content' => [$isPut ? 'required' : 'sometimes', 'string'],
+            'author' => [$isPut ? 'required' : 'sometimes', 'string', 'max:100']
+        ];
+
+        $validated = $request->validate($rules);
+
+        $post->fill($validated)->save();
+
+        return response()->json($post);
+    }
+
+    /**
+     * 삭제
+     * - DELETE /api/posts/{id}
+     */
+    public function destroy(Post $post)
+    {
+        $post->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    /** @use HasFactory<\Database\Factories\PostFactory> */
+    use HasFactory;
+
+    protected $fillable = ['title', 'content', 'author'];
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
+        api: __DIR__.'/../routes/api.php',
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Post>
+ */
+class PostFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/2025_08_14_043915_create_posts_table.php
+++ b/database/migrations/2025_08_14_043915_create_posts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');    // 제목
+            $table->text('content');    // 내용
+            $table->string('author');   // 작성자
+            $table->timestamps();       // 작성일(created_at), updated_at
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PostSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\PostController;
+use Illuminate\Support\Facades\Route;
+
+Route::apiResource('posts', PostController::class);


### PR DESCRIPTION
이 풀 리퀘스트는 게시글(Post)에 대한 CRUD 기능을 구현합니다. 포함된 변경 사항은 다음과 같습니다.

- 게시글 샘플 데이터를 시드하기 위한 `PostFactory`와 `PostSeeder` 생성
- API 라우트 정의 및 `posts` 엔드포인트 설정
- 게시글 CRUD 처리를 위한 `PostController` 전체 메서드 구현
- `fillable` 필드가 정의된 `Post` 모델 생성
- 데이터베이스에 posts 테이블을 생성하는 마이그레이션 스크립트 추가